### PR TITLE
Avoid implying that an audit of one contest implies that an entire election has been audited

### DIFF
--- a/WebContent/explain_assertions.html
+++ b/WebContent/explain_assertions.html
@@ -12,12 +12,12 @@
 <body>
 <h2><a href="https://www.democracydevelopers.org.au/"><img style="height:4em;" src="https://www.democracydevelopers.org.au/wp-content/uploads/2023/02/kangaroo-badge-1.png"/></a> Show the effect of assertions</h2>
 <p>This graphically shows the implications of a set
-    of assertions about an IRV (instant runoff) election
+    of assertions about an IRV (instant runoff) contest
     which hopefully combine to conclude that there is only one
     possible winning candidate.</p>
 <p>This is useful if you have been convinced (from auditing) that
    each of the individual assertions is true, and now want to
-   see what that implies about the whole election. This page
+   see what that implies about the whole contest This page
    demonstrates the logic in a manner that is reasonable for a human
    (rather than a computer) to check.</p>
 


### PR DESCRIPTION
A major misunderstanding in the realm of risk-limiting audits is that auditing one or two contests is the same as auditing an entire election with dozens or hundreds of contests.

To help head that off, this simple edit changes the word "election" to "contest". I dare say similar changes are merited elsewhere in this and related repositories, but wanted to at least get a start.